### PR TITLE
add display for response

### DIFF
--- a/src/components/RemsInterface/RemsInterface.css
+++ b/src/components/RemsInterface/RemsInterface.css
@@ -77,6 +77,29 @@ body {
   animation-timing-function: ease-in-out; 
 }
 
+.requestBody{
+  overflow-y: scroll;
+  height:500px;
+}
+.jsonData{
+  line-height:16px;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 14px;
+
+  border-left: 2px solid #dddddd;
+  border-top:0px;
+  padding-left:6px;
+
+  display:block;
+}
+
+.elementBody{
+  color:#adadad;
+}
+.elementKey{
+  color:#343434
+}
+
 @keyframes spin {
   from {
       transform:rotate(0deg);

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -50,22 +50,22 @@ export default class RemsInterface extends Component {
     return options;
   }
 
-  unfurlJson(jsonData, level){
+  unfurlJson(jsonData, level) {
     var divStyle = {
-        marginLeft:20
-      };
-    if(jsonData){
-        return Object.keys(jsonData).map(element=>{
-            var elementKey = `${element}-${level}`;
-            return (
-            <div id = {elementKey} className="jsonData" key={element} style={divStyle}>
-                <span className="elementKey">{element}</span>: <span className="elementBody">{jsonData[element]===null?"null":typeof jsonData[element] === "object"?this.unfurlJson(jsonData[element], level + 1):jsonData[element]}</span>
-            </div>
-            )
-        });
+      marginLeft: 20
+    };
+    if (jsonData) {
+      return Object.keys(jsonData).map(element => {
+        var elementKey = `${element}-${level}`;
+        return (
+          <div id={elementKey} className="jsonData" key={element} style={divStyle}>
+            <span className="elementKey">{element}</span>: <span className="elementBody">{jsonData[element] === null ? "null" : typeof jsonData[element] === "object" ? this.unfurlJson(jsonData[element], level + 1) : jsonData[element]}</span>
+          </div>
+        )
+      });
     }
 
-}
+  }
 
   async sendRemsMessage() {
     const remsAdminResponse = await axios.post("http://localhost:8090/api/rems", this.props.specialtyRxBundle, this.getAxiosOptions());
@@ -81,21 +81,21 @@ export default class RemsInterface extends Component {
   }
 
   toggleBundle() {
-    this.setState((prevState)=>{
-      return {...prevState, viewBundle: !prevState.viewBundle}
+    this.setState((prevState) => {
+      return { ...prevState, viewBundle: !prevState.viewBundle }
     })
   }
 
   toggleResponse() {
     console.log(this.state.viewResponse);
-    this.setState((prevState)=>{
-      return {...prevState, viewResponse: !prevState.viewResponse}
+    this.setState((prevState) => {
+      return { ...prevState, viewResponse: !prevState.viewResponse }
     })
   }
 
   togglePisBundle() {
-    this.setState((prevState)=>{
-      return {...prevState, viewPisBundle: !prevState.viewPisBundle}
+    this.setState((prevState) => {
+      return { ...prevState, viewPisBundle: !prevState.viewPisBundle }
     })
   }
 
@@ -112,15 +112,15 @@ export default class RemsInterface extends Component {
   }
 
   refreshPisBundle() {
-    this.setState({spinPis: true});
-    axios.get(`http://localhost:3010/api/doctorOrder/${this.state.response.data.doctorOrder._id}`).then((response)=>{
-      this.setState({response: response});
+    this.setState({ spinPis: true });
+    axios.get(`http://localhost:3010/api/doctorOrder/${this.state.response.data.doctorOrder._id}`).then((response) => {
+      this.setState({ response: response });
     })
   }
   refreshBundle() {
-    this.setState({spin: true});
-    axios.get(`http://localhost:8090/api/rems/${this.state.remsAdminResponse.data.case_number}`).then((response)=>{
-      this.setState({remsAdminResponse: response});
+    this.setState({ spin: true });
+    axios.get(`http://localhost:8090/api/rems/${this.state.remsAdminResponse.data.case_number}`).then((response) => {
+      this.setState({ remsAdminResponse: response });
     })
   }
   render() {
@@ -132,7 +132,7 @@ export default class RemsInterface extends Component {
       color = "#f0ad4e"
     }
 
-    let colorPis  = "#f7f7f7"
+    let colorPis = "#f7f7f7"
     const statusPis = this.state.response?.data?.doctorOrder?.dispenseStatus;
 
     if (statusPis === "Approved") {
@@ -147,7 +147,7 @@ export default class RemsInterface extends Component {
       <div>
         <div className="container left-form">
           <h1>REMS Admin Status</h1>
-          <Paper style={{paddingBottom: "5px"}}>
+          <Paper style={{ paddingBottom: "5px" }}>
             <div className="status-icon" style={{ backgroundColor: color }}></div>
             <div className="bundle-entry">
               Case Number : {this.state.remsAdminResponse?.data?.case_number || "N/A"}
@@ -159,27 +159,27 @@ export default class RemsInterface extends Component {
               <Button variant="contained" onClick={this.toggleBundle}>View Bundle</Button>
               <Button variant="contained" onClick={this.toggleResponse}>View Response</Button>
 
-              {this.state.remsAdminResponse?.data?.case_number ? 
-                            <AutorenewIcon
-                            className={this.state.spin === true ? "refresh" : "renew-icon"}
-                            onClick={this.refreshBundle}
-                            onAnimationEnd={() => this.setState({spin: false})}
-                        />
-                      :""
-                }
+              {this.state.remsAdminResponse?.data?.case_number ?
+                <AutorenewIcon
+                  className={this.state.spin === true ? "refresh" : "renew-icon"}
+                  onClick={this.refreshBundle}
+                  onAnimationEnd={() => this.setState({ spin: false })}
+                />
+                : ""
+              }
 
             </div>
 
           </Paper>
-          {this.state.viewResponse?
-                 <div className="requestBody">
-                 { this.unfurlJson(this.state.remsAdminResponse, 0) }
-                 </div>
-                 :
-                 ""}
+          {this.state.viewResponse ?
+            <div className="requestBody">
+              {this.unfurlJson(this.state.remsAdminResponse, 0)}
+            </div>
+            :
+            ""}
           {this.state.viewBundle ? <div className="bundle-view">
             {this.renderBundle(this.props.specialtyRxBundle)}
-          </div>: ""}
+          </div> : ""}
 
 
 
@@ -187,31 +187,31 @@ export default class RemsInterface extends Component {
 
         <div className="right-form">
           <h1>Pharmacy Status</h1>
-          <Paper style={{paddingBottom: "5px"}}>
-              <div className="status-icon" style={{ backgroundColor: colorPis }}></div>
-              <div className="bundle-entry">
-                ID : {this.state.response?.data?.doctorOrder?._id || "N/A"}
-              </div>
-              <div className="bundle-entry">
-                Status: {this.state.response?.data?.doctorOrder?.dispenseStatus}
-              </div>
-              <div className="bundle-entry">
-                <Button variant="contained" onClick={this.togglePisBundle}>View Bundle</Button>
-                {this.state.response?.data?.doctorOrder?._id ? 
-                              <AutorenewIcon
-                              className={this.state.spinPis === true ? "refresh" : "renew-icon"}
-                              onClick={this.refreshPisBundle}
-                              onAnimationEnd={() => this.setState({spinPis: false})}
-                          />
-                        :""
-                  }
+          <Paper style={{ paddingBottom: "5px" }}>
+            <div className="status-icon" style={{ backgroundColor: colorPis }}></div>
+            <div className="bundle-entry">
+              ID : {this.state.response?.data?.doctorOrder?._id || "N/A"}
+            </div>
+            <div className="bundle-entry">
+              Status: {this.state.response?.data?.doctorOrder?.dispenseStatus}
+            </div>
+            <div className="bundle-entry">
+              <Button variant="contained" onClick={this.togglePisBundle}>View Bundle</Button>
+              {this.state.response?.data?.doctorOrder?._id ?
+                <AutorenewIcon
+                  className={this.state.spinPis === true ? "refresh" : "renew-icon"}
+                  onClick={this.refreshPisBundle}
+                  onAnimationEnd={() => this.setState({ spinPis: false })}
+                />
+                : ""
+              }
 
-              </div>
+            </div>
 
-            </Paper>
-            {this.state.viewPisBundle ? <div className="bundle-view">
+          </Paper>
+          {this.state.viewPisBundle ? <div className="bundle-view">
             {this.renderBundle(this.props.specialtyRxBundle)}
-          </div>: ""}
+          </div> : ""}
         </div>
         {/* <button className="submit-btn" onClick={() => { this.sendRemsMessage() }}>Submit</button> */}
 

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -68,7 +68,7 @@ export default class RemsInterface extends Component {
   }
 
   async sendRemsMessage() {
-    const remsAdminResponse = await axios.post("http://localhost:8090/api/rems", this.props.specialtyRxBundle, this.getAxiosOptions());
+    const remsAdminResponse = await axios.post("http://localhost:8090/rems", this.props.specialtyRxBundle, this.getAxiosOptions());
     this.setState({ remsAdminResponse });
     console.log(remsAdminResponse)
     axios.post("http://localhost:3010/api/doctorOrder/fhir/rems", remsAdminResponse.data, this.getAxiosOptions()).then((response) => {
@@ -173,7 +173,7 @@ export default class RemsInterface extends Component {
           </Paper>
           {this.state.viewResponse ?
             <div className="requestBody">
-              {this.unfurlJson(this.state.remsAdminResponse, 0)}
+              {this.unfurlJson(this.state.remsAdminResponse?.data, 0)}
             </div>
             :
             ""}

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -119,7 +119,7 @@ export default class RemsInterface extends Component {
   }
   refreshBundle() {
     this.setState({ spin: true });
-    axios.get(`http://localhost:8090/api/rems/${this.state.remsAdminResponse.data.case_number}`).then((response) => {
+    axios.get(`http://localhost:8090/rems/${this.state.remsAdminResponse.data.case_number}`).then((response) => {
       this.setState({ remsAdminResponse: response });
     })
   }

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -21,6 +21,7 @@ export default class RemsInterface extends Component {
       response: null,
       spin: false,
       spinPis: false,
+      viewResponse: false,
       viewBundle: false,
       viewPisBundle: false,
     };
@@ -31,6 +32,8 @@ export default class RemsInterface extends Component {
     this.refreshBundle = this.refreshBundle.bind(this);
     this.refreshPisBundle = this.refreshPisBundle.bind(this);
     this.toggleBundle = this.toggleBundle.bind(this);
+    this.toggleResponse = this.toggleResponse.bind(this);
+
     this.togglePisBundle = this.togglePisBundle.bind(this);
   }
 
@@ -46,6 +49,23 @@ export default class RemsInterface extends Component {
     };
     return options;
   }
+
+  unfurlJson(jsonData, level){
+    var divStyle = {
+        marginLeft:20
+      };
+    if(jsonData){
+        return Object.keys(jsonData).map(element=>{
+            var elementKey = `${element}-${level}`;
+            return (
+            <div id = {elementKey} className="jsonData" key={element} style={divStyle}>
+                <span className="elementKey">{element}</span>: <span className="elementBody">{jsonData[element]===null?"null":typeof jsonData[element] === "object"?this.unfurlJson(jsonData[element], level + 1):jsonData[element]}</span>
+            </div>
+            )
+        });
+    }
+
+}
 
   async sendRemsMessage() {
     const remsAdminResponse = await axios.post("http://localhost:8090/api/rems", this.props.specialtyRxBundle, this.getAxiosOptions());
@@ -63,6 +83,13 @@ export default class RemsInterface extends Component {
   toggleBundle() {
     this.setState((prevState)=>{
       return {...prevState, viewBundle: !prevState.viewBundle}
+    })
+  }
+
+  toggleResponse() {
+    console.log(this.state.viewResponse);
+    this.setState((prevState)=>{
+      return {...prevState, viewResponse: !prevState.viewResponse}
     })
   }
 
@@ -130,6 +157,8 @@ export default class RemsInterface extends Component {
             </div>
             <div className="bundle-entry">
               <Button variant="contained" onClick={this.toggleBundle}>View Bundle</Button>
+              <Button variant="contained" onClick={this.toggleResponse}>View Response</Button>
+
               {this.state.remsAdminResponse?.data?.case_number ? 
                             <AutorenewIcon
                             className={this.state.spin === true ? "refresh" : "renew-icon"}
@@ -142,6 +171,12 @@ export default class RemsInterface extends Component {
             </div>
 
           </Paper>
+          {this.state.viewResponse?
+                 <div className="requestBody">
+                 { this.unfurlJson(this.state.remsAdminResponse, 0) }
+                 </div>
+                 :
+                 ""}
           {this.state.viewBundle ? <div className="bundle-view">
             {this.renderBundle(this.props.specialtyRxBundle)}
           </div>: ""}


### PR DESCRIPTION
Shows the json of the response from the rems admin.  Currently the rems admin response is a little messy, and not very useful.  It contains the entire bundle, which clutters out relevant information, though with what little new information is actually contained in the bundle, the status and case number fields basically cover it.

Should generalize for later iterations of the response, the code just displays json.