### PR TITLE
temp fix for id match

### DIFF
--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -184,8 +184,6 @@ export default class QuestionnaireForm extends Component {
     // search for any QuestionnaireResponses
     this.smart.request(this.getRetrieveSaveQuestionnaireUrl() +
       "&subject=" + this.getPatient()).then((result) => {
-        console.log("hello")
-        console.log(result);
         this.popupClear("Would you like to load a previous form?", "Cancel", false);
         this.processSavedQuestionnaireResponses(result, true);
       }, ((result) => {

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -1452,12 +1452,15 @@ export default class QuestionnaireForm extends Component {
 
         const savedParentItem = findSavedParentItem(parentLinkId, savedItem);
         const replaceOrInsertItem = (newResponseItem, savedParentItem) => {
-          const replaceIndex = savedParentItem.item.findIndex(item => item.linkId == newResponseItem.linkId);
-          if (replaceIndex != -1) {
-            savedParentItem.item[replaceIndex] = newResponseItem;
-          } else {
-            savedParentItem.item.push(newResponseItem);
+          if(savedParentItem.item) {
+            const replaceIndex = savedParentItem.item.findIndex(item => item.linkId == newResponseItem.linkId);
+            if (replaceIndex != -1) {
+              savedParentItem.item[replaceIndex] = newResponseItem;
+            } else {
+              savedParentItem.item.push(newResponseItem);
+            }
           }
+
         };
         if (savedParentItem != undefined) {
           replaceOrInsertItem(newItem, savedParentItem);

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -184,7 +184,8 @@ export default class QuestionnaireForm extends Component {
     // search for any QuestionnaireResponses
     this.smart.request(this.getRetrieveSaveQuestionnaireUrl() +
       "&subject=" + this.getPatient()).then((result) => {
-
+        console.log("hello")
+        console.log(result);
         this.popupClear("Would you like to load a previous form?", "Cancel", false);
         this.processSavedQuestionnaireResponses(result, true);
       }, ((result) => {
@@ -236,7 +237,7 @@ export default class QuestionnaireForm extends Component {
       let count = 0;
 
       partialResponses.entry.forEach(r => {
-        if (this.props.qform.id == r.resource.questionnaire) {
+        if (r.resource.questionnaire.includes(this.props.qform.id)) {
           count = count + 1;
           // add the option to the popupOptions
           let date = new Date(r.resource.authored);


### PR DESCRIPTION
DTR changed its Questionnaire/Template in the appContext to be a full URL, but still tries to match a simple ID when looking for questionnaires to relaunch.  This fixes the problem, at least until the upstream branch moves ahead and fixes this problem in a more complete way.