### PR TITLE
REMS-232 dtr UI clean up & Prescriber form view 

### DIFF
--- a/src/components/RemsInterface/RemsInterface.css
+++ b/src/components/RemsInterface/RemsInterface.css
@@ -2,8 +2,8 @@ body {
     margin: 0;
     padding: 0;
     font-family: sans-serif;
-  
   }
+
   .left-form { 
     width: 48%;
     float: left;
@@ -28,7 +28,6 @@ body {
     background-color: #ededed;
     padding-top: 20px;
     padding-bottom:20px;
-    
   }
 
   .resource-entry:hover {
@@ -46,12 +45,10 @@ body {
     background-color: #ededed;
   }
 
-
 .submit-btn {
     float: right;
     margin-top: 6px;
   }
-
 
 .submit-btn:hover{
     border-width:1px 3px 1px 1px;
@@ -72,6 +69,7 @@ body {
   cursor: pointer;
   margin-left: 15px;
 }
+
 .refresh{
   cursor: pointer;
   margin-left: 15px;
@@ -85,6 +83,7 @@ body {
   overflow-y: scroll;
   height:500px;
 }
+
 .jsonData{
   line-height:16px;
   font-family: 'Courier New', Courier, monospace;
@@ -100,6 +99,7 @@ body {
 .elementBody{
   color:#adadad;
 }
+
 .elementKey{
   color:#343434
 }
@@ -112,7 +112,6 @@ body {
       transform:rotate(360deg);
   }
 }
-
 
 /*  ETASU styling */
 .resource-entry-hover{

--- a/src/components/RemsInterface/RemsInterface.css
+++ b/src/components/RemsInterface/RemsInterface.css
@@ -21,13 +21,14 @@ body {
   }
 
   .resource-entry{
-    clear: both;
+    /* clear: both; */
     border-left: 4px solid #ffcccb;
     padding: 5px;
     border-bottom: 1px solid grey;
     background-color: #ededed;
     padding-top: 20px;
     padding-bottom:20px;
+    
   }
 
   .resource-entry:hover {
@@ -121,9 +122,9 @@ body {
 }
 
 .etasu-container{
-  padding-bottom:10px;
-  padding-left: 10px;
-  padding-right:10px;
+  padding-bottom:40px;
+  padding-left: 20px;
+  padding-right:20px;
 }
 
 .resource-entry-text{
@@ -132,11 +133,10 @@ body {
   width:75%;
 }
 
-.etasu-container:hover > .resource-entry-hover{
+.resource-entry:hover > .resource-entry-hover{
   clear: both;
   display: block !important;
 }
-
 
 .resource-entry-icon{
   width:25%;

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -56,21 +56,17 @@ export default class RemsInterface extends Component {
       console.log(metReq);
       return (
         <div>
-          <div className={"resource-entry"}>
-            <div className={"etasu-container"}>
+          <div className={"resource-entry etasu-container"}>
               <div className={"resource-entry-text"}  >{metReq.requirement.name}</div>
               <div className={"resource-entry-icon"}>{metReq.completed ? "✅"  : "❌"}</div>
               <div className={"resource-entry-hover"}>{metReq.requirement.description}</div>
-            </div>
           </div>
           {
             metReq.childMetRequirements.map(subMetReq =>    
-              <div className={"resource-entry resource-child"}>
-                <div className={"etasu-container"}>
+              <div className={"resource-entry resource-child etasu-container"}>
                   <div className={"resource-entry-text"}>{subMetReq.requirement.name}</div>
                   <div className={"resource-entry-icon"}>{subMetReq.completed ? "✅" : "❌"}</div>
                   <div className={"resource-entry-hover"}>{subMetReq.requirement.description}</div>
-                </div>
               </div>
             )
           }
@@ -203,12 +199,14 @@ export default class RemsInterface extends Component {
           </Paper>
           {this.state.viewResponse ?
             <div className="bundle-view">
+              <br></br>
               <h3>ETASU</h3>
               {this.unfurlJson(this.state.remsAdminResponse?.data, 0)}
             </div>
             :
             ""}
           {this.state.viewBundle ? <div className="bundle-view">
+          <br></br>
           <h3>Bundle</h3>
             {this.renderBundle(this.props.specialtyRxBundle)}
           </div> : ""}

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -80,11 +80,15 @@ export default class RemsInterface extends Component {
     const remsAdminResponse = await axios.post("http://localhost:8090/rems", this.props.specialtyRxBundle, this.getAxiosOptions());
     this.setState({ remsAdminResponse });
     console.log(remsAdminResponse)
-    axios.post("http://localhost:3010/api/doctorOrder/$process-message", remsAdminResponse.data, this.getAxiosOptions()).then((response) => {
-      this.setState({ response });
-      console.log(response);
-      console.log(response.data);
-    });
+
+    // Will not send post request to PIS if only for prescriber enrollment
+    if(this.state.remsAdminResponse?.data?.case_number){
+      axios.post("http://localhost:3010/api/doctorOrder/$process-message", remsAdminResponse.data, this.getAxiosOptions()).then((response) => {
+        this.setState({ response });
+        console.log(response);
+        console.log(response.data);
+      });
+    }
   }
 
   toggleBundle() {

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -57,39 +57,39 @@ export default class RemsInterface extends Component {
       return (
         <div>
           <div className={"resource-entry etasu-container"}>
-              <div className={"resource-entry-text"}  >{metReq.requirement.name}</div>
+            <div className={"resource-entry-text"}  >{metReq.requirement.name}</div>
               <div className={"resource-entry-icon"}>{metReq.completed ? "✅"  : "❌"}</div>
-              <div className={"resource-entry-hover"}>{metReq.requirement.description}</div>
+            <div className={"resource-entry-hover"}>{metReq.requirement.description}</div>
           </div>
           {
-            metReq.childMetRequirements.map(subMetReq =>    
+            metReq.childMetRequirements.map(subMetReq =>
               <div className={"resource-entry resource-child etasu-container"}>
-                  <div className={"resource-entry-text"}>{subMetReq.requirement.name}</div>
-                  <div className={"resource-entry-icon"}>{subMetReq.completed ? "✅" : "❌"}</div>
-                  <div className={"resource-entry-hover"}>{subMetReq.requirement.description}</div>
+                <div className={"resource-entry-text"}>{subMetReq.requirement.name}</div>
+                <div className={"resource-entry-icon"}>{subMetReq.completed ? "✅" : "❌"}</div>
+                <div className={"resource-entry-hover"}>{subMetReq.requirement.description}</div>
               </div>
             )
           }
         </div>
       )
     });
-      
-    }
-    // if (jsonData) {
-    //   return Object.keys(jsonData).map(element => {
-    //     console.log(element);
-    //     return (
-    //       // <div id={elementKey} className="jsonData" key={element} style={divStyle}>
-    //       //   <span className="elementKey">{element}</span>: <span className="elementBody">{jsonData[element] === null ? "null" : typeof jsonData[element] === "object" ? this.unfurlJson(jsonData[element], level + 1) : jsonData[element]}</span>
-    //       // </div>
-    //       <div>
-    //         <div className={"resource-entry"}>
-    //             <div>TEST</div>
-    //         </div>
-    //       </div>
-    //     )
-    //   });
-    // }
+
+  }
+  // if (jsonData) {
+  //   return Object.keys(jsonData).map(element => {
+  //     console.log(element);
+  //     return (
+  //       // <div id={elementKey} className="jsonData" key={element} style={divStyle}>
+  //       //   <span className="elementKey">{element}</span>: <span className="elementBody">{jsonData[element] === null ? "null" : typeof jsonData[element] === "object" ? this.unfurlJson(jsonData[element], level + 1) : jsonData[element]}</span>
+  //       // </div>
+  //       <div>
+  //         <div className={"resource-entry"}>
+  //             <div>TEST</div>
+  //         </div>
+  //       </div>
+  //     )
+  //   });
+  // }
 
   // }
 
@@ -169,84 +169,120 @@ export default class RemsInterface extends Component {
       colorPis = "#0275d8"
     }
 
+    // Checking if REMS Request (pt enrollment) || Met Requirments (prescriber Form)
+    let hasRemsCase = this.state.remsAdminResponse?.data?.case_number ? true : false;
+
     return (
       <div>
-        <div className="container left-form">
-          <h1>REMS Admin Status</h1>
-          <Paper style={{ paddingBottom: "5px" }}>
-            <div className="status-icon" style={{ backgroundColor: color }}></div>
-            <div className="bundle-entry">
-              Case Number : {this.state.remsAdminResponse?.data?.case_number || "N/A"}
-            </div>
-            <div className="bundle-entry">
-              Status: {this.state.remsAdminResponse?.data?.status}
-            </div>
-            <div className="bundle-entry">
-              <Button variant="contained" onClick={this.toggleBundle}>View Bundle</Button>
-              <Button variant="contained" onClick={this.toggleResponse}>View ETASU</Button>
+        {hasRemsCase ?
+          <div>
+            <div className="container left-form">
+              <h1>REMS Admin Status</h1>
+              <Paper style={{ paddingBottom: "5px" }}>
+                <div className="status-icon" style={{ backgroundColor: color }}></div>
+                <div className="bundle-entry">
+                  Case Number : {this.state.remsAdminResponse?.data?.case_number || "N/A"}
+                </div>
+                <div className="bundle-entry">
+                  Status: {this.state.remsAdminResponse?.data?.status}
+                </div>
+                <div className="bundle-entry">
+                  <Button variant="contained" onClick={this.toggleBundle}>View Bundle</Button>
+                  <Button variant="contained" onClick={this.toggleResponse}>View ETASU</Button>
 
-              {this.state.remsAdminResponse?.data?.case_number ?
-                <AutorenewIcon
-                  className={this.state.spin === true ? "refresh" : "renew-icon"}
-                  onClick={this.refreshBundle}
-                  onAnimationEnd={() => this.setState({ spin: false })}
-                />
-                : ""
-              }
+                  {this.state.remsAdminResponse?.data?.case_number ?
+                    <AutorenewIcon
+                      className={this.state.spin === true ? "refresh" : "renew-icon"}
+                      onClick={this.refreshBundle}
+                      onAnimationEnd={() => this.setState({ spin: false })}
+                    />
+                    : ""
+                  }
 
-            </div>
+                </div>
 
-          </Paper>
-          {this.state.viewResponse ?
-            <div className="bundle-view">
-              <br></br>
-              <h3>ETASU</h3>
-              {this.unfurlJson(this.state.remsAdminResponse?.data, 0)}
-            </div>
-            :
-            ""}
-          {this.state.viewBundle ? <div className="bundle-view">
-          <br></br>
-          <h3>Bundle</h3>
-            {this.renderBundle(this.props.specialtyRxBundle)}
-          </div> : ""}
-
-
-
-        </div>
-
-        <div className="right-form">
-          <h1>Pharmacy Status</h1>
-          <Paper style={{ paddingBottom: "5px" }}>
-            <div className="status-icon" style={{ backgroundColor: colorPis }}></div>
-            <div className="bundle-entry">
-              ID : {this.state.response?.data?.doctorOrder?._id || "N/A"}
-            </div>
-            <div className="bundle-entry">
-              Status: {this.state.response?.data?.doctorOrder?.dispenseStatus}
-            </div>
-            <div className="bundle-entry">
-              <Button variant="contained" onClick={this.togglePisBundle}>View Bundle</Button>
-              {this.state.response?.data?.doctorOrder?._id ?
-                <AutorenewIcon
-                  className={this.state.spinPis === true ? "refresh" : "renew-icon"}
-                  onClick={this.refreshPisBundle}
-                  onAnimationEnd={() => this.setState({ spinPis: false })}
-                />
-                : ""
-              }
+              </Paper>
+              {this.state.viewResponse ?
+                <div className="bundle-view">
+                  <br></br>
+                  <h3>ETASU</h3>
+                  {this.unfurlJson(this.state.remsAdminResponse?.data, 0)}
+                </div>
+                :
+                ""}
+              {this.state.viewBundle ? <div className="bundle-view">
+                <br></br>
+                <h3>Bundle</h3>
+                {this.renderBundle(this.props.specialtyRxBundle)}
+              </div> : ""}
 
             </div>
 
-          </Paper>
-          {this.state.viewPisBundle ? <div className="bundle-view">
-            <br></br>
-            <h3>Bundle</h3>
-            {this.renderBundle(this.props.specialtyRxBundle)}
-          </div> : ""}
-        </div>
-        {/* <button className="submit-btn" onClick={() => { this.sendRemsMessage() }}>Submit</button> */}
+            <div className="right-form">
+              <h1>Pharmacy Status</h1>
+              <Paper style={{ paddingBottom: "5px" }}>
+                <div className="status-icon" style={{ backgroundColor: colorPis }}></div>
+                <div className="bundle-entry">
+                  ID : {this.state.response?.data?.doctorOrder?._id || "N/A"}
+                </div>
+                <div className="bundle-entry">
+                  Status: {this.state.response?.data?.doctorOrder?.dispenseStatus}
+                </div>
+                <div className="bundle-entry">
+                  <Button variant="contained" onClick={this.togglePisBundle}>View Bundle</Button>
+                  {this.state.response?.data?.doctorOrder?._id ?
+                    <AutorenewIcon
+                      className={this.state.spinPis === true ? "refresh" : "renew-icon"}
+                      onClick={this.refreshPisBundle}
+                      onAnimationEnd={() => this.setState({ spinPis: false })}
+                    />
+                    : ""
+                  }
 
+                </div>
+
+              </Paper>
+              {this.state.viewPisBundle ? <div className="bundle-view">
+                <br></br>
+                <h3>Bundle</h3>
+                {this.renderBundle(this.props.specialtyRxBundle)}
+              </div> : ""}
+            </div>
+            {/* <button className="submit-btn" onClick={() => { this.sendRemsMessage() }}>Submit</button> */}
+          </div>
+          :
+          <div>
+            <div className="container left-form">
+              <h1>Prescriber Document Status</h1>
+              <Paper style={{ paddingBottom: "5px" }}>
+                <div className="status-icon" style={{ backgroundColor: "#5cb85c" }}></div>
+                <div className="bundle-entry">
+                  Status: Documents successfully submitted
+                </div>
+                <div className="bundle-entry">
+                  <Button variant="contained" onClick={this.toggleBundle}>View Bundle</Button>
+
+                  {this.state.remsAdminResponse?.data?.case_number ?
+                    <AutorenewIcon
+                      className={this.state.spin === true ? "refresh" : "renew-icon"}
+                      onClick={this.refreshBundle}
+                      onAnimationEnd={() => this.setState({ spin: false })}
+                    />
+                    : ""
+                  }
+
+                </div>
+
+              </Paper>
+              {this.state.viewBundle ? <div className="bundle-view">
+                <br></br>
+                <h3>Bundle</h3>
+                {this.renderBundle(this.props.specialtyRxBundle)}
+              </div> : ""}
+
+            </div>
+          </div>
+        }
       </div>
     )
   }

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -240,6 +240,8 @@ export default class RemsInterface extends Component {
 
           </Paper>
           {this.state.viewPisBundle ? <div className="bundle-view">
+            <br></br>
+            <h3>Bundle</h3>
             {this.renderBundle(this.props.specialtyRxBundle)}
           </div> : ""}
         </div>

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -203,11 +203,13 @@ export default class RemsInterface extends Component {
           </Paper>
           {this.state.viewResponse ?
             <div className="bundle-view">
+              <h3>ETASU</h3>
               {this.unfurlJson(this.state.remsAdminResponse?.data, 0)}
             </div>
             :
             ""}
           {this.state.viewBundle ? <div className="bundle-view">
+          <h3>Bundle</h3>
             {this.renderBundle(this.props.specialtyRxBundle)}
           </div> : ""}
 

--- a/src/components/RemsInterface/RemsInterface.jsx
+++ b/src/components/RemsInterface/RemsInterface.jsx
@@ -75,23 +75,6 @@ export default class RemsInterface extends Component {
     });
 
   }
-  // if (jsonData) {
-  //   return Object.keys(jsonData).map(element => {
-  //     console.log(element);
-  //     return (
-  //       // <div id={elementKey} className="jsonData" key={element} style={divStyle}>
-  //       //   <span className="elementKey">{element}</span>: <span className="elementBody">{jsonData[element] === null ? "null" : typeof jsonData[element] === "object" ? this.unfurlJson(jsonData[element], level + 1) : jsonData[element]}</span>
-  //       // </div>
-  //       <div>
-  //         <div className={"resource-entry"}>
-  //             <div>TEST</div>
-  //         </div>
-  //       </div>
-  //     )
-  //   });
-  // }
-
-  // }
 
   async sendRemsMessage() {
     const remsAdminResponse = await axios.post("http://localhost:8090/rems", this.props.specialtyRxBundle, this.getAxiosOptions());
@@ -102,8 +85,6 @@ export default class RemsInterface extends Component {
       console.log(response);
       console.log(response.data);
     });
-
-
   }
 
   toggleBundle() {
@@ -143,12 +124,14 @@ export default class RemsInterface extends Component {
       this.setState({ response: response });
     })
   }
+
   refreshBundle() {
     this.setState({ spin: true });
     axios.get(`http://localhost:8090/rems/${this.state.remsAdminResponse.data.case_number}`).then((response) => {
       this.setState({ remsAdminResponse: response });
     })
   }
+
   render() {
     const status = this.state.remsAdminResponse?.data?.status;
     let color = "#f7f7f7"
@@ -238,7 +221,6 @@ export default class RemsInterface extends Component {
                     />
                     : ""
                   }
-
                 </div>
 
               </Paper>
@@ -248,7 +230,6 @@ export default class RemsInterface extends Component {
                 {this.renderBundle(this.props.specialtyRxBundle)}
               </div> : ""}
             </div>
-            {/* <button className="submit-btn" onClick={() => { this.sendRemsMessage() }}>Submit</button> */}
           </div>
           :
           <div>
@@ -270,7 +251,6 @@ export default class RemsInterface extends Component {
                     />
                     : ""
                   }
-
                 </div>
 
               </Paper>


### PR DESCRIPTION
**Wait for Sahil to merge his changes in first** 

- Created a UI for a single requirement being submitted that does not have a rems case associated with it. 
->To Test: Submit prescriber document, either enrollment or education form. 

- Added separation if the bundle and ETASU are visible at the same time.
- Hover on “view ETASU” on REMS admin page on DTR attached to parent div for more consistent hover.